### PR TITLE
refactor: make createHealthFilterFn read-only (remove state writes from query context)

### DIFF
--- a/inference-chain/x/inference/keeper/circuit_breaker_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_test.go
@@ -190,9 +190,9 @@ func TestHealthFilterExcludesHighMissRate(t *testing.T) {
 	// Should be excluded due to high miss rate
 	require.Empty(t, result, "node with >25% miss rate should be excluded")
 
-	// Check CB state was updated
+	// Filter is now read-only: CB state must remain Healthy (EndBlock handles state transition)
 	entry := k.GetCBEntry(ctx, cbAddr1)
-	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State)
 }
 
 // TestHealthFilterIncludesHealthyNode verifies healthy nodes pass the filter.
@@ -265,9 +265,11 @@ func TestHealthFilterProbeNodePromotedOnCooldownExpiry(t *testing.T) {
 	members := makeCBMockMembers(cbAddr1)
 	result := filter(members)
 
-	require.Len(t, result, 1, "excluded node with expired cooldown should be promoted to probe and included")
+	require.Len(t, result, 1, "excluded node with expired cooldown should be included (probe pending EndBlock)")
+
+	// Filter is now read-only: CB state must remain Excluded (EndBlock handles EXCLUDED → PROBE transition)
 	entry := k.GetCBEntry(ctx, cbAddr1)
-	require.Equal(t, keeperpkg.CBStateProbe, entry.State)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State)
 }
 
 // TestHealthFilterExcludedNodeStillInCooldown verifies that an excluded node

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -122,9 +122,10 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 	}, nil
 }
 
-// createHealthFilterFn builds a fast circuit-breaker filter that excludes nodes with high
-// current-epoch miss rates, manages PROBE state transitions on cooldown expiry, and falls back
-// to the full member list if all candidates are excluded (safety valve).
+// createHealthFilterFn builds a read-only circuit-breaker filter that excludes nodes with high
+// current-epoch miss rates, includes cooldown-expired nodes for probe (state written by EndBlock),
+// and falls back to the full member list if all candidates are excluded (safety valve).
+// This function makes no writes to state — all CB state transitions are handled by EndBlock.
 func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
 	return func(members []*group.GroupMember) []*group.GroupMember {
 		filtered := make([]*group.GroupMember, 0, len(members))
@@ -148,10 +149,10 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 			case CBStateExcluded:
 				cooldownDone := blockHeight >= cb.ExcludedAtBlock+cb.CooldownBlocks
 				if cooldownDone {
-					// Cooldown expired — promote to PROBE so it gets one test slot.
-					k.PromoteCBEntryToProbe(goCtx, address, blockHeight)
+					// Cooldown expired — include the node so it gets one test slot.
+					// EndBlock will handle the EXCLUDED → PROBE state transition.
 					filtered = append(filtered, m)
-					k.Logger().Info("CircuitBreaker: promoted excluded node to probe",
+					k.Logger().Info("CircuitBreaker: including cooldown-expired node (probe pending EndBlock)",
 						"address", address, "blockHeight", blockHeight)
 				} else {
 					blocksRemaining := (cb.ExcludedAtBlock + cb.CooldownBlocks) - blockHeight
@@ -176,9 +177,9 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 
 				total := inferenceCount + missedRequests
 				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
-					// Miss rate exceeded threshold — exclude immediately.
-					k.ExcludeCBEntry(goCtx, address, blockHeight, false)
-					k.Logger().Info("CircuitBreaker: excluding node due to high miss rate",
+					// Miss rate exceeded threshold — exclude from selection pool.
+					// EndBlock will handle the state transition to CBStateExcluded.
+					k.Logger().Debug("CircuitBreaker: excluding unhealthy node (exclusion pending EndBlock)",
 						"address", address, "blockHeight", blockHeight,
 						"inferenceCount", inferenceCount,
 						"missedRequests", missedRequests,


### PR DESCRIPTION
## Summary

Addresses issue #19 — PR 1 of 3 for the upstream-compatible circuit breaker redesign.

## Changes

### `keeper/query_get_random_executor.go`

- **`CBStateExcluded` branch**: Removed `k.PromoteCBEntryToProbe()` call. The filter now includes cooldown-expired nodes without writing any state. EndBlock (PR 2) will handle the `EXCLUDED → PROBE` transition.
- **`CBStateHealthy` branch**: Removed `k.ExcludeCBEntry()` call. The filter now excludes high-miss-rate nodes from the selection pool without writing any state. EndBlock will handle the `HEALTHY → EXCLUDED` transition.
- Updated function comment to document the read-only contract.

### `keeper/circuit_breaker_test.go`

- `TestHealthFilterExcludesHighMissRate`: Filter exclusion behavior unchanged; updated CB state assertion to `CBStateHealthy` (state no longer written by filter).
- `TestHealthFilterProbeNodePromotedOnCooldownExpiry`: Node inclusion unchanged; updated CB state assertion to `CBStateExcluded` (state no longer written by filter).

## Acceptance Criteria

- [x] `createHealthFilterFn` makes no calls to `SetCBEntry`, `ExcludeCBEntry`, or `PromoteCBEntryToProbe`
- [x] The filter still correctly includes/excludes nodes from the selection pool
- [x] Tests updated to reflect read-only filter behavior
- [x] No writes occur in any query handler