### PR TITLE
feat: Add UpdateCBStateForBlock to EndBlock — move CB writes out of query context

### DIFF
--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -170,6 +170,72 @@ func (k Keeper) PromoteCBEntryToProbe(ctx context.Context, address string, block
 		"probeAttempts", entry.ProbeAttempts)
 }
 
+// GetAllCBEntries returns all stored circuit breaker entries.
+// Used by EndBlock to apply state transitions across the full CB table.
+func (k Keeper) GetAllCBEntries(ctx context.Context) []CircuitBreakerEntry {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CircuitBreakerStateKey))
+
+	iter := store.Iterator(nil, nil)
+	defer iter.Close()
+
+	var entries []CircuitBreakerEntry
+	for ; iter.Valid(); iter.Next() {
+		var entry CircuitBreakerEntry
+		if err := json.Unmarshal(iter.Value(), &entry); err != nil {
+			k.Logger().Error("GetAllCBEntries: failed to unmarshal entry", "error", err)
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// UpdateCBStateForBlock processes circuit breaker state transitions for the current block.
+// Must be called from EndBlock (write context only).
+//
+// It performs two passes:
+// 1. Promote any EXCLUDED entries whose cooldown has expired to PROBE state.
+// 2. Scan active participants and exclude any HEALTHY nodes that have crossed the
+//    miss-rate threshold (DefaultCBMissThresholdPct, DefaultCBMinSamples).
+func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
+	// Pass 1: EXCLUDED → PROBE promotion for expired cooldowns
+	entries := k.GetAllCBEntries(ctx)
+	for _, entry := range entries {
+		if entry.State == CBStateExcluded {
+			if blockHeight >= entry.ExcludedAtBlock+entry.CooldownBlocks {
+				k.PromoteCBEntryToProbe(ctx, entry.Address, blockHeight)
+				k.Logger().Info("CircuitBreaker: promoted expired entry to probe",
+					"address", entry.Address, "blockHeight", blockHeight)
+			}
+		}
+	}
+
+	// Pass 2: HEALTHY → EXCLUDED for high-miss-rate participants
+	participants := k.GetAllParticipant(ctx)
+	for _, p := range participants {
+		if p.CurrentEpochStats == nil {
+			continue
+		}
+		inferenceCount := p.CurrentEpochStats.InferenceCount
+		missedRequests := p.CurrentEpochStats.MissedRequests
+		total := inferenceCount + missedRequests
+
+		// Only apply threshold if node already has a clean bill of health (not already excluded/probe)
+		existing := k.GetCBEntry(ctx, p.Index)
+		if existing.State != CBStateHealthy {
+			continue
+		}
+
+		if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+			k.ExcludeCBEntry(ctx, p.Index, blockHeight, false)
+			k.Logger().Info("CircuitBreaker: excluded node via EndBlock miss-rate check",
+				"address", p.Index, "inferenceCount", inferenceCount,
+				"missedRequests", missedRequests, "blockHeight", blockHeight)
+		}
+	}
+}
+
 // RecordCBResult updates the circuit breaker state after an inference result.
 // success=true: node completed inference → restore to HEALTHY.
 // success=false: node missed/timed out → re-exclude with doubled cooldown.

--- a/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker_endblock_test.go
@@ -1,0 +1,151 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keeper2 "github.com/productscience/inference/testutil/keeper"
+	keeperpkg "github.com/productscience/inference/x/inference/keeper"
+	"github.com/productscience/inference/x/inference/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateCBStateForBlock_ExcludesHighMissRate verifies that a participant with
+// >25% miss rate and ≥4 samples gets excluded during EndBlock.
+func TestUpdateCBStateForBlock_ExcludesHighMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 1 hit, 3 misses = 75% miss rate — above 25% threshold, total=4 ≥ min_samples
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State, "node with >25% miss rate and ≥4 samples should be excluded")
+}
+
+// TestUpdateCBStateForBlock_PromotesExpiredExclusion verifies that an EXCLUDED entry
+// with an expired cooldown gets promoted to PROBE state in EndBlock.
+func TestUpdateCBStateForBlock_PromotesExpiredExclusion(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	excludedAtBlock := int64(100)
+	cooldownBlocks := int64(50)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  cooldownBlocks,
+	})
+
+	// blockHeight >= excludedAtBlock + cooldownBlocks → cooldown expired
+	blockHeight := excludedAtBlock + cooldownBlocks + 1
+
+	k.UpdateCBStateForBlock(ctx, blockHeight)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State, "EXCLUDED entry with expired cooldown should be promoted to PROBE")
+}
+
+// TestUpdateCBStateForBlock_SkipsLowMissRate verifies that a participant below the
+// miss-rate threshold stays HEALTHY after EndBlock.
+func TestUpdateCBStateForBlock_SkipsLowMissRate(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// 9 hits, 1 miss = 10% miss rate — below 25% threshold
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 9,
+			MissedRequests: 1,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateHealthy, entry.State, "node below miss-rate threshold should remain HEALTHY")
+}
+
+// TestUpdateCBStateForBlock_SkipsAlreadyExcluded verifies that a node already in
+// EXCLUDED state is not re-excluded by the miss-rate pass.
+func TestUpdateCBStateForBlock_SkipsAlreadyExcluded(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to EXCLUDED state with a non-expired cooldown
+	excludedAtBlock := int64(100)
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:         cbAddr1,
+		State:           keeperpkg.CBStateExcluded,
+		ExcludedAtBlock: excludedAtBlock,
+		CooldownBlocks:  keeperpkg.DefaultCBMaxCooldownBlocks,
+		ProbeAttempts:   1,
+	})
+
+	// Also set a participant with high miss rate
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	// blockHeight within cooldown to avoid promotion
+	blockHeight := excludedAtBlock + 10
+
+	k.UpdateCBStateForBlock(ctx, blockHeight)
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateExcluded, entry.State, "already-EXCLUDED node should not be re-excluded by miss-rate pass")
+	// ProbeAttempts should remain unchanged (no re-exclusion happened)
+	require.Equal(t, int32(1), entry.ProbeAttempts, "probe attempts should be unchanged for already-EXCLUDED node")
+}
+
+// TestUpdateCBStateForBlock_SkipsProbeNodes verifies that PROBE-state nodes are
+// not modified by the miss-rate pass in EndBlock.
+func TestUpdateCBStateForBlock_SkipsProbeNodes(t *testing.T) {
+	k, ctx := keeper2.InferenceKeeper(t)
+
+	// Set node to PROBE state
+	k.SetCBEntry(ctx, keeperpkg.CircuitBreakerEntry{
+		Address:        cbAddr1,
+		State:          keeperpkg.CBStateProbe,
+		CooldownBlocks: keeperpkg.DefaultCBInitialCooldownBlocks,
+	})
+
+	// Participant with high miss rate — should be ignored because node is in PROBE
+	participant := types.Participant{
+		Index:   cbAddr1,
+		Address: cbAddr1,
+		Status:  types.ParticipantStatus_ACTIVE,
+		CurrentEpochStats: &types.CurrentEpochStats{
+			InferenceCount: 1,
+			MissedRequests: 3,
+		},
+	}
+	err := k.SetParticipant(ctx, participant)
+	require.NoError(t, err)
+
+	k.UpdateCBStateForBlock(ctx, ctx.BlockHeight())
+
+	entry := k.GetCBEntry(ctx, cbAddr1)
+	require.Equal(t, keeperpkg.CBStateProbe, entry.State, "PROBE node should not be modified by miss-rate pass")
+}

--- a/inference-chain/x/inference/module/module.go
+++ b/inference-chain/x/inference/module/module.go
@@ -374,6 +374,8 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 		am.keeper.RemoveInferenceTimeout(ctx, t.ExpirationHeight, t.InferenceId)
 	}
 
+	am.keeper.UpdateCBStateForBlock(ctx, blockHeight)
+
 	err = am.keeper.Prune(ctx, int64(currentEpoch.Index))
 	if err != nil {
 		am.LogError("Error during pruning", types.Pruning, "error", err.Error())


### PR DESCRIPTION
## Summary

Implements `UpdateCBStateForBlock` in the keeper and wires it into `EndBlock`, completing PR 2 of 3 for the circuit breaker redesign (issue #18).

## Changes

### `keeper/circuit_breaker.go`
- **`GetAllCBEntries`**: iterates the full CB store, returning all entries. Used by EndBlock to scan for cooldown promotions.
- **`UpdateCBStateForBlock`**: two-pass EndBlock logic:
  - Pass 1: promotes EXCLUDED entries whose cooldown has expired to PROBE state
  - Pass 2: scans all participants and excludes HEALTHY nodes that have crossed the miss-rate threshold (>25% with ≥4 samples)

### `module/module.go`
- Calls `am.keeper.UpdateCBStateForBlock(ctx, blockHeight)` in `EndBlock` after inference expiry handling, before pruning.

### `keeper/circuit_breaker_endblock_test.go` (new)
Five tests covering all acceptance criteria:
1. `TestUpdateCBStateForBlock_ExcludesHighMissRate` — node with >25% miss rate and ≥4 samples is excluded
2. `TestUpdateCBStateForBlock_PromotesExpiredExclusion` — EXCLUDED entry with expired cooldown promoted to PROBE
3. `TestUpdateCBStateForBlock_SkipsLowMissRate` — node below threshold stays HEALTHY
4. `TestUpdateCBStateForBlock_SkipsAlreadyExcluded` — already-EXCLUDED node not re-excluded by miss-rate pass
5. `TestUpdateCBStateForBlock_SkipsProbeNodes` — PROBE nodes not modified by miss-rate pass

## Notes
- Depends on PR #19 (read-only filter) for full redesign completion
- At most 1-block latency for exclusions — acceptable for this use case
- O(n) over participant store per block, consistent with other EndBlock scans

Addresses issue #20