### PR TITLE
feat: promote circuit breaker params to ValidationParams proto

### DIFF
--- a/inference-chain/proto/inference/inference/params.proto
+++ b/inference-chain/proto/inference/inference/params.proto
@@ -104,6 +104,12 @@ message ValidationParams {
   Decimal quick_failure_threshold = 23; // The threshold of probabilty of consecutive failures to cause a quick invalidation
   Decimal binom_test_p0 = 24; // The null hypothesis probability for the binomial test (default 0.10)
   bool claim_validation_enabled = 25; // Enables claim-time validation checks in MsgClaimRewards
+
+  // Circuit breaker parameters (governance-adjustable without a chain upgrade)
+  uint64 cb_miss_threshold_pct = 26;       // miss rate % (0–100) above which a node is excluded (default 25)
+  uint64 cb_min_samples = 27;              // minimum inferences before threshold applies (default 4)
+  int64  cb_initial_cooldown_blocks = 28;  // initial exclusion cooldown in blocks (~5 min at 5s/block; default 50)
+  int64  cb_max_cooldown_blocks = 29;      // max cooldown with exponential backoff (~50 min; default 500)
 }
 
 message PoCModelParams {

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -22,8 +22,8 @@ const (
 )
 
 // Default circuit breaker parameters.
-// These are intentionally kept as Go constants (not proto params) for the initial implementation.
-// They can be promoted to ValidationParams fields once the proto pipeline is updated.
+// These compile-time constants are used as fallback defaults when the governance
+// parameters (ValidationParams.CbMissThresholdPct etc.) are not set (zero value).
 const (
 	// DefaultCBMissThresholdPct is the miss-rate percentage (0–100) above which a node is excluded.
 	DefaultCBMissThresholdPct = uint64(25)
@@ -37,6 +37,44 @@ const (
 	// ~50 minutes at 5 s/block.
 	DefaultCBMaxCooldownBlocks = int64(500)
 )
+
+// cbParams holds the resolved circuit-breaker tuning parameters for a single call.
+type cbParams struct {
+	MissThresholdPct      uint64
+	MinSamples            uint64
+	InitialCooldownBlocks int64
+	MaxCooldownBlocks     int64
+}
+
+// getCBParams reads CB parameters from ValidationParams and falls back to Go
+// compile-time defaults for any field that is zero (unset).
+func (k Keeper) getCBParams(ctx context.Context) cbParams {
+	p := cbParams{
+		MissThresholdPct:      DefaultCBMissThresholdPct,
+		MinSamples:            DefaultCBMinSamples,
+		InitialCooldownBlocks: DefaultCBInitialCooldownBlocks,
+		MaxCooldownBlocks:     DefaultCBMaxCooldownBlocks,
+	}
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return p
+	}
+	if vp := params.ValidationParams; vp != nil {
+		if vp.CbMissThresholdPct != 0 {
+			p.MissThresholdPct = vp.CbMissThresholdPct
+		}
+		if vp.CbMinSamples != 0 {
+			p.MinSamples = vp.CbMinSamples
+		}
+		if vp.CbInitialCooldownBlocks != 0 {
+			p.InitialCooldownBlocks = vp.CbInitialCooldownBlocks
+		}
+		if vp.CbMaxCooldownBlocks != 0 {
+			p.MaxCooldownBlocks = vp.CbMaxCooldownBlocks
+		}
+	}
+	return p
+}
 
 // CircuitBreakerEntry holds the per-node state managed by the fast circuit breaker.
 type CircuitBreakerEntry struct {
@@ -127,17 +165,18 @@ func (k Keeper) ClearAllCBState(ctx context.Context) {
 // If the node was already excluded (re-exclusion during probe), the cooldown doubles (capped).
 func (k Keeper) ExcludeCBEntry(ctx context.Context, address string, blockHeight int64, reExclusion bool) {
 	entry := k.GetCBEntry(ctx, address)
+	cbp := k.getCBParams(ctx)
 
 	newCooldown := entry.CooldownBlocks
 	if newCooldown <= 0 {
-		newCooldown = DefaultCBInitialCooldownBlocks
+		newCooldown = cbp.InitialCooldownBlocks
 	}
 
 	if reExclusion {
 		// Exponential backoff: double the cooldown
 		newCooldown *= 2
-		if newCooldown > DefaultCBMaxCooldownBlocks {
-			newCooldown = DefaultCBMaxCooldownBlocks
+		if newCooldown > cbp.MaxCooldownBlocks {
+			newCooldown = cbp.MaxCooldownBlocks
 		}
 		entry.ProbeAttempts++
 	}
@@ -197,8 +236,10 @@ func (k Keeper) GetAllCBEntries(ctx context.Context) []CircuitBreakerEntry {
 // It performs two passes:
 // 1. Promote any EXCLUDED entries whose cooldown has expired to PROBE state.
 // 2. Scan active participants and exclude any HEALTHY nodes that have crossed the
-//    miss-rate threshold (DefaultCBMissThresholdPct, DefaultCBMinSamples).
+//    miss-rate threshold (read from ValidationParams, falling back to Go constant defaults).
 func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
+	cbp := k.getCBParams(ctx)
+
 	// Pass 1: EXCLUDED → PROBE promotion for expired cooldowns
 	entries := k.GetAllCBEntries(ctx)
 	for _, entry := range entries {
@@ -227,7 +268,7 @@ func (k Keeper) UpdateCBStateForBlock(ctx context.Context, blockHeight int64) {
 			continue
 		}
 
-		if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+		if total >= cbp.MinSamples && missedRequests*100 > cbp.MissThresholdPct*total {
 			k.ExcludeCBEntry(ctx, p.Index, blockHeight, false)
 			k.Logger().Info("CircuitBreaker: excluded node via EndBlock miss-rate check",
 				"address", p.Index, "inferenceCount", inferenceCount,

--- a/inference-chain/x/inference/keeper/query_get_random_executor.go
+++ b/inference-chain/x/inference/keeper/query_get_random_executor.go
@@ -126,7 +126,10 @@ func (k Keeper) createFilterFn(goCtx context.Context, modelId string) (func(memb
 // current-epoch miss rates, includes cooldown-expired nodes for probe (state written by EndBlock),
 // and falls back to the full member list if all candidates are excluded (safety valve).
 // This function makes no writes to state — all CB state transitions are handled by EndBlock.
+// CB tuning parameters are read from ValidationParams (governance-adjustable), falling back to
+// the compile-time constant defaults when not set.
 func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) func([]*group.GroupMember) []*group.GroupMember {
+	cbp := k.getCBParams(goCtx)
 	return func(members []*group.GroupMember) []*group.GroupMember {
 		filtered := make([]*group.GroupMember, 0, len(members))
 
@@ -176,7 +179,7 @@ func (k Keeper) createHealthFilterFn(goCtx context.Context, blockHeight int64) f
 				}
 
 				total := inferenceCount + missedRequests
-				if total >= DefaultCBMinSamples && missedRequests*100 > DefaultCBMissThresholdPct*total {
+				if total >= cbp.MinSamples && missedRequests*100 > cbp.MissThresholdPct*total {
 					// Miss rate exceeded threshold — exclude from selection pool.
 					// EndBlock will handle the state transition to CBStateExcluded.
 					k.Logger().Debug("CircuitBreaker: excluding unhealthy node (exclusion pending EndBlock)",

--- a/inference-chain/x/inference/types/params.go
+++ b/inference-chain/x/inference/types/params.go
@@ -209,6 +209,11 @@ func DefaultValidationParams() *ValidationParams {
 		QuickFailureThreshold:          DecimalFromFloat(0.000001),
 		BinomTestP0:                    DecimalFromFloat(0.10),
 		ClaimValidationEnabled:         false,
+		// Circuit breaker parameters — match the Go constant defaults in circuit_breaker.go
+		CbMissThresholdPct:      25,
+		CbMinSamples:            4,
+		CbInitialCooldownBlocks: 50,
+		CbMaxCooldownBlocks:     500,
 	}
 }
 

--- a/inference-chain/x/inference/types/params.pb.go
+++ b/inference-chain/x/inference/types/params.pb.go
@@ -621,6 +621,11 @@ type ValidationParams struct {
 	QuickFailureThreshold          *Decimal `protobuf:"bytes,23,opt,name=quick_failure_threshold,json=quickFailureThreshold,proto3" json:"quick_failure_threshold,omitempty"`
 	BinomTestP0                    *Decimal `protobuf:"bytes,24,opt,name=binom_test_p0,json=binomTestP0,proto3" json:"binom_test_p0,omitempty"`
 	ClaimValidationEnabled         bool     `protobuf:"varint,25,opt,name=claim_validation_enabled,json=claimValidationEnabled,proto3" json:"claim_validation_enabled,omitempty"`
+	// Circuit breaker parameters (governance-adjustable without a chain upgrade)
+	CbMissThresholdPct      uint64 `protobuf:"varint,26,opt,name=cb_miss_threshold_pct,json=cbMissThresholdPct,proto3" json:"cb_miss_threshold_pct,omitempty"`
+	CbMinSamples            uint64 `protobuf:"varint,27,opt,name=cb_min_samples,json=cbMinSamples,proto3" json:"cb_min_samples,omitempty"`
+	CbInitialCooldownBlocks int64  `protobuf:"varint,28,opt,name=cb_initial_cooldown_blocks,json=cbInitialCooldownBlocks,proto3" json:"cb_initial_cooldown_blocks,omitempty"`
+	CbMaxCooldownBlocks     int64  `protobuf:"varint,29,opt,name=cb_max_cooldown_blocks,json=cbMaxCooldownBlocks,proto3" json:"cb_max_cooldown_blocks,omitempty"`
 }
 
 func (m *ValidationParams) Reset()         { *m = ValidationParams{} }
@@ -829,6 +834,34 @@ func (m *ValidationParams) GetClaimValidationEnabled() bool {
 		return m.ClaimValidationEnabled
 	}
 	return false
+}
+
+func (m *ValidationParams) GetCbMissThresholdPct() uint64 {
+	if m != nil {
+		return m.CbMissThresholdPct
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbMinSamples() uint64 {
+	if m != nil {
+		return m.CbMinSamples
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbInitialCooldownBlocks() int64 {
+	if m != nil {
+		return m.CbInitialCooldownBlocks
+	}
+	return 0
+}
+
+func (m *ValidationParams) GetCbMaxCooldownBlocks() int64 {
+	if m != nil {
+		return m.CbMaxCooldownBlocks
+	}
+	return 0
 }
 
 type PoCModelParams struct {
@@ -2551,6 +2584,18 @@ func (this *ValidationParams) Equal(that interface{}) bool {
 	if this.ClaimValidationEnabled != that1.ClaimValidationEnabled {
 		return false
 	}
+	if this.CbMissThresholdPct != that1.CbMissThresholdPct {
+		return false
+	}
+	if this.CbMinSamples != that1.CbMinSamples {
+		return false
+	}
+	if this.CbInitialCooldownBlocks != that1.CbInitialCooldownBlocks {
+		return false
+	}
+	if this.CbMaxCooldownBlocks != that1.CbMaxCooldownBlocks {
+		return false
+	}
 	return true
 }
 func (this *PoCModelParams) Equal(that interface{}) bool {
@@ -3643,6 +3688,34 @@ func (m *ValidationParams) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.CbMaxCooldownBlocks != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMaxCooldownBlocks))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.CbInitialCooldownBlocks != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbInitialCooldownBlocks))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.CbMinSamples != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMinSamples))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.CbMissThresholdPct != 0 {
+		i = encodeVarintParams(dAtA, i, uint64(m.CbMissThresholdPct))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd0
+	}
 	if m.ClaimValidationEnabled {
 		i--
 		if m.ClaimValidationEnabled {
@@ -5174,6 +5247,18 @@ func (m *ValidationParams) Size() (n int) {
 	}
 	if m.ClaimValidationEnabled {
 		n += 3
+	}
+	if m.CbMissThresholdPct != 0 {
+		n += 2 + sovParams(uint64(m.CbMissThresholdPct))
+	}
+	if m.CbMinSamples != 0 {
+		n += 2 + sovParams(uint64(m.CbMinSamples))
+	}
+	if m.CbInitialCooldownBlocks != 0 {
+		n += 2 + sovParams(uint64(m.CbInitialCooldownBlocks))
+	}
+	if m.CbMaxCooldownBlocks != 0 {
+		n += 2 + sovParams(uint64(m.CbMaxCooldownBlocks))
 	}
 	return n
 }
@@ -7953,6 +8038,82 @@ func (m *ValidationParams) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.ClaimValidationEnabled = bool(v != 0)
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMissThresholdPct", wireType)
+			}
+			m.CbMissThresholdPct = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMissThresholdPct |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 27:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMinSamples", wireType)
+			}
+			m.CbMinSamples = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMinSamples |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbInitialCooldownBlocks", wireType)
+			}
+			m.CbInitialCooldownBlocks = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbInitialCooldownBlocks |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 29:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CbMaxCooldownBlocks", wireType)
+			}
+			m.CbMaxCooldownBlocks = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowParams
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CbMaxCooldownBlocks |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipParams(dAtA[iNdEx:])


### PR DESCRIPTION
## Summary

Addresses issue #21. PR 3 of 3 for the upstream-compatible circuit breaker redesign (depends on PRs #19 and #20 — both now merged).

This makes the CB tuning parameters governance-configurable rather than hardcoded Go constants.

## Changes

### Proto (`params.proto`)
Added four new fields to `ValidationParams`:
- `cb_miss_threshold_pct = 26` (uint64, default 25) — miss rate % above which a node is excluded
- `cb_min_samples = 27` (uint64, default 4) — minimum inferences before threshold applies
- `cb_initial_cooldown_blocks = 28` (int64, default 50) — initial exclusion cooldown (~5 min at 5s/block)
- `cb_max_cooldown_blocks = 29` (int64, default 500) — max cooldown with exponential backoff (~50 min)

### `params.pb.go` (manual update — no protoc tooling)
- Added struct fields with correct protobuf field tags
- Added getter methods
- Updated `Equal`, `MarshalToSizedBuffer`, `Size`, and `Unmarshal`

### `types/params.go`
- `DefaultValidationParams()` now sets CB fields to values matching the Go constant defaults (25%, 4 samples, 50 blocks, 500 blocks)

### `keeper/circuit_breaker.go`
- Updated constant comments — they're now compile-time fallbacks
- Added `cbParams` struct and `getCBParams(ctx)` helper that reads from `ValidationParams` with zero-value fallback to constants
- `ExcludeCBEntry` uses `getCBParams` for initial and max cooldown
- `UpdateCBStateForBlock` uses `getCBParams` for miss-rate threshold and min-samples checks

### `keeper/query_get_random_executor.go`
- `createHealthFilterFn` calls `getCBParams` at construction time and uses governance params for miss-rate filtering

## Backward Compatibility
- Default values exactly match the previous hardcoded constants — no behavior change on upgrade
- Existing tests pass unchanged: the test keeper initializes with `DefaultParams()` which now includes the CB fields
- Zero-value fallback ensures nodes upgrading from older state (params without CB fields) get the original defaults

## Governance
A governance proposal can now update CB behavior without a chain upgrade:
```
inferenced tx gov submit-proposal update-params --cb-miss-threshold-pct 20 --cb-min-samples 5 ...
```