### PR TITLE
chore: circuit breaker follow-up cleanup

### DIFF
--- a/inference-chain/x/inference/epochgroup/random.go
+++ b/inference-chain/x/inference/epochgroup/random.go
@@ -75,7 +75,12 @@ func (eg *EpochGroup) GetRandomMember(
 // PoC voting weights (ValidationWeights[].Weight) and the cosmos-sdk group member
 // weights (used for block production) are NOT modified; this map is used solely by
 // the executor-selection lottery.
+//
+// Returns an empty map if GroupData or ValidationWeights is nil.
 func (eg *EpochGroup) buildSelectionWeightsMap() map[string]int64 {
+	if eg.GroupData == nil {
+		return make(map[string]int64)
+	}
 	weights := make(map[string]int64, len(eg.GroupData.ValidationWeights))
 	for _, vw := range eg.GroupData.ValidationWeights {
 		if vw == nil {

--- a/inference-chain/x/inference/keeper/circuit_breaker.go
+++ b/inference-chain/x/inference/keeper/circuit_breaker.go
@@ -48,6 +48,15 @@ type cbParams struct {
 
 // getCBParams reads CB parameters from ValidationParams and falls back to Go
 // compile-time defaults for any field that is zero (unset).
+//
+// NOTE: Zero-value governance override caveat — because zero is used as a sentinel
+// for "unset" (triggering the default fallback), it is not possible to set any of
+// these parameters to 0 via a governance proposal. For example, setting
+// CbMissThresholdPct=0 to disable threshold-based exclusion will be silently
+// ignored and the default (DefaultCBMissThresholdPct=25) will be used instead.
+// This is intentional: a threshold of 0 would immediately exclude every node.
+// If disabling the circuit breaker is needed, prefer very large values
+// (e.g. CbMissThresholdPct=100 or CbMinSamples=MaxUint64) rather than zero.
 func (k Keeper) getCBParams(ctx context.Context) cbParams {
 	p := cbParams{
 		MissThresholdPct:      DefaultCBMissThresholdPct,

--- a/inference-chain/x/inference/types/keys.go
+++ b/inference-chain/x/inference/types/keys.go
@@ -75,9 +75,11 @@ var (
 	SubnetEscrowCounterPrefix              = collections.NewPrefix(49)
 	SubnetEscrowEpochCountPrefix           = collections.NewPrefix(50)
 	SubnetHostEpochStatsPrefix             = collections.NewPrefix(51)
-	SubnetEscrowsByEpochPrefix             = collections.NewPrefix(52)
-	CircuitBreakerStatePrefix              = collections.NewPrefix(53)
-	ParamsKey                              = []byte("p_inference")
+	SubnetEscrowsByEpochPrefix = collections.NewPrefix(52)
+	// Note: prefix 53 is reserved for circuit breaker state; the implementation uses
+	// the string-based CircuitBreakerStateKey with KeyPrefix() for consistency with
+	// other string-keyed stores in this module. Do not reuse prefix 53.
+	ParamsKey = []byte("p_inference")
 )
 
 func KeyPrefix(p string) []byte {


### PR DESCRIPTION
## Summary

Follow-up cleanup items from the reviewer's feedback on the circuit breaker + reputation-adjusted selection PR (reviewed in issue #30).

### Changes

1. **Remove dead `CircuitBreakerStatePrefix`** (`types/keys.go`) — The `collections.NewPrefix(53)` variable was defined but never referenced; all CB store access uses the string-based `CircuitBreakerStateKey` with `KeyPrefix()` consistently. A comment now reserves prefix 53 to prevent accidental reuse.

2. **Nil guard in `buildSelectionWeightsMap`** (`epochgroup/random.go`) — Adds a defensive `eg.GroupData == nil` check to prevent a nil-pointer panic. In practice `GroupData` is always set by `NewEpochGroup`, but the guard is cheap and makes the invariant explicit.

3. **Document zero-value governance param caveat** (`keeper/circuit_breaker.go`) — `getCBParams` treats zero as "unset" (falls back to compile-time defaults). This means operators cannot disable CB enforcement by setting a param to 0 via governance. The new comment explains why (0 would exclude every node) and recommends using large values instead.

Addresses issue #30